### PR TITLE
MEM-369 Add mutation to allow admins to update user bio

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -336,8 +336,8 @@
   "bundlesize": [
     {
       "path": "./dist/static/assets/js/embed.js",
-      "maxSize": "30.05 kB",
-      "maxSizeOld": "17 kB"
+      "maxSize": "50 kB",
+      "maxSizeOld": "30.05 kB"
     },
     {
       "path": "./dist/static/assets/js/count.js",

--- a/server/src/core/server/graph/mutators/Users.ts
+++ b/server/src/core/server/graph/mutators/Users.ts
@@ -34,6 +34,7 @@ import {
   suspend,
   updateAvatar,
   updateBio,
+  updateBioByID,
   updateEmail,
   updateEmailByID,
   updateEmailNotificationSettings,
@@ -90,6 +91,7 @@ import {
   GQLUpdateSSOProfileIDInput,
   GQLUpdateUserAvatarInput,
   GQLUpdateUserBanInput,
+  GQLUpdateUserBioInput,
   GQLUpdateUserEmailInput,
   GQLUpdateUserMediaSettingsInput,
   GQLUpdateUserMembershipScopesInput,
@@ -513,4 +515,6 @@ export const Users = (ctx: GraphContext) => ({
       ctx.user!,
       ctx.now
     ),
+  updateUserBio: async (input: GQLUpdateUserBioInput) =>
+    updateBioByID(ctx.mongo, ctx.cache, ctx.tenant, input.userID, input.bio),
 });

--- a/server/src/core/server/graph/resolvers/Mutation.ts
+++ b/server/src/core/server/graph/resolvers/Mutation.ts
@@ -219,6 +219,10 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     user: await ctx.mutators.Users.updateUserEmail(input),
     clientMutationId: input.clientMutationId,
   }),
+  updateUserBio: async (source, { input }, ctx) => ({
+    user: await ctx.mutators.Users.updateUserBio(input),
+    clientMutationId: input.clientMutationId,
+  }),
   updateUserAvatar: async (source, { input }, ctx) => ({
     user: await ctx.mutators.Users.updateUserAvatar(input),
     clientMutationId: input.clientMutationId,

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -9053,6 +9053,39 @@ type UpdateUserEmailPayload {
 }
 
 ##################
+# updateUserBio
+##################
+
+input UpdateUserBioInput {
+  """
+  userID is the ID of the User that should have their bio updated.
+  """
+  userID: ID!
+
+  """
+  bio is the bio to set for the User.
+  """
+  bio: String!
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+type UpdateUserBioPayload {
+  """
+  user is the possibly modified User.
+  """
+  user: User!
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+##################
 # updateUserAvatar
 ##################
 
@@ -11596,33 +11629,4 @@ type Subscription {
   commentEdited returns when a Comment is edited.
   """
   commentEdited(storyID: ID!): CommentEditedPayload!
-}
-
-input UpdateUserBioInput {
-  """
-  userID is the ID of the User that should have their bio updated.
-  """
-  userID: ID!
-
-  """
-  bio is the bio to set for the User.
-  """
-  bio: String!
-
-  """
-  clientMutationId is required for Relay support.
-  """
-  clientMutationId: String!
-}
-
-type UpdateUserBioPayload {
-  """
-  user is the possibly modified User.
-  """
-  user: User!
-
-  """
-  clientMutationId is required for Relay support.
-  """
-  clientMutationId: String!
 }

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -10919,6 +10919,13 @@ type Mutation {
     @auth(roles: [ADMIN])
 
   """
+  updateUserBio allows administrators to update a given User's bio
+  to the one provided.
+  """
+  updateUserBio(input: UpdateUserBioInput!): UpdateUserBioPayload!
+    @auth(roles: [ADMIN])
+
+  """
   updateUserAvatar allows administrators to update a given User's avatar to the
   one provided.
   """
@@ -11589,4 +11596,33 @@ type Subscription {
   commentEdited returns when a Comment is edited.
   """
   commentEdited(storyID: ID!): CommentEditedPayload!
+}
+
+input UpdateUserBioInput {
+  """
+  userID is the ID of the User that should have their bio updated.
+  """
+  userID: ID!
+
+  """
+  bio is the bio to set for the User.
+  """
+  bio: String!
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+type UpdateUserBioPayload {
+  """
+  user is the possibly modified User.
+  """
+  user: User!
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
 }

--- a/server/src/core/server/services/users/users.ts
+++ b/server/src/core/server/services/users/users.ts
@@ -1405,6 +1405,35 @@ export async function updateEmailByID(
 }
 
 /**
+ * updateBioByID will update a given User's bio. For use by administrators.
+ * @param mongo mongo database to interact with
+ * @param cache cache to invalidate
+ * @param tenant Tenant where the User will be interacted with
+ * @param userID the User's ID that we are updating
+ * @param bio the bio that we are setting on the User
+ */
+export async function updateBioByID(
+  mongo: MongoContext,
+  cache: DataCache,
+  tenant: Tenant,
+  userID: string,
+  bio?: string
+) {
+  if (bio && bio.length > MAX_BIO_LENGTH) {
+    throw new UserBioTooLongError(userID);
+  }
+
+  const updatedUser = await updateUserBio(mongo, tenant.id, userID, bio);
+
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.users.update(updatedUser);
+  }
+
+  return updatedUser;
+}
+
+/**
  * updateBio will update the given User's bio.
  * @param mongo mongo database to interact with
  * @param tenant Tenant where the User will be interacted with


### PR DESCRIPTION
Added mutation to allow admins to update user bio - needed to anonymise users on Coral as part of the user delete process.